### PR TITLE
Refactor login view body to conditionally render Apple Sign-In button

### DIFF
--- a/lib/features/auth/presentation/view/login/widget/login_view_body.dart
+++ b/lib/features/auth/presentation/view/login/widget/login_view_body.dart
@@ -1,5 +1,5 @@
-import 'dart:io';
-
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'dart:io' show Platform;
 import 'package:e_commerce/core/constants/images.dart';
 import 'package:e_commerce/features/auth/presentation/manger/login/login_cubit.dart';
 import 'package:e_commerce/features/auth/presentation/view/login/widget/dont_have_an_accont.dart';
@@ -45,18 +45,19 @@ class _LoginViewBodyState extends State<LoginViewBody> {
             ),
             SizedBox(height: 10.h),
             // Apple Sign-In Button
-            Platform.isIOS
-                ? Column(
-                    children: [
-                      SocialLoginButton(
-                        title: 'تسجيل بواسطة أبل',
-                        image: Assets.assetsImagesApplIcon,
-                        onPressed: () {},
-                      ),
-                      SizedBox(height: 10.h),
-                    ],
-                  )
-                : SizedBox(),
+            if (!kIsWeb && Platform.isIOS)
+              Column(
+                children: [
+                  SocialLoginButton(
+                    title: 'تسجيل بواسطة أبل',
+                    image: Assets.assetsImagesApplIcon,
+                    onPressed: () {},
+                  ),
+                  SizedBox(height: 10.h),
+                ],
+              )
+            else
+              SizedBox(),
             // Facebook Sign-In Button
             SocialLoginButton(
               title: 'تسجيل بواسطة فيسبوك',


### PR DESCRIPTION
Previously, the Apple Sign-In button was only conditionally rendered based on whether the platform was iOS. However, this logic did not account for web environments, leading to potential runtime errors. This commit refactors the conditional rendering to use `kIsWeb` from the `flutter/foundation.dart` package, ensuring that the Apple Sign-In button is only rendered on iOS devices and not in web environments. This change improves the robustness of the login view body widget.